### PR TITLE
# fix for jcenter repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Maven:
   <repository>
     <id>central</id>
     <name>bintray</name>
-    <url>http://jcenter.bintray.com</url>
+    <url>https://jcenter.bintray.com</url>
   </repository>
 </repositories>
 ```


### PR DESCRIPTION
[https://jfrog.com/blog/secure-jcenter-with-https/](https://jfrog.com/blog/secure-jcenter-with-https/)

Hello.
I fixed `readme.md` file. Because `jcenter` support only https.

Thank you for good library.