### PR TITLE
Added possibility to specify NotificationHandlingStrategy when sending notification

### DIFF
--- a/src/main/java/an/awesome/pipelinr/Pipeline.java
+++ b/src/main/java/an/awesome/pipelinr/Pipeline.java
@@ -5,4 +5,6 @@ public interface Pipeline {
   <R, C extends Command<R>> R send(C command);
 
   <N extends Notification> void send(N notification);
+
+  <N extends Notification> void send(N notification, NotificationHandlingStrategy notificationHandlingStrategy);
 }

--- a/src/main/java/an/awesome/pipelinr/Pipelinr.java
+++ b/src/main/java/an/awesome/pipelinr/Pipelinr.java
@@ -65,7 +65,7 @@ public class Pipelinr implements Pipeline {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <N extends Notification> void send(N notification) {
+  public <N extends Notification> void send(N notification, NotificationHandlingStrategy notificationHandlingStrategy) {
     checkArgument(notification, "Notification must not be null");
 
     List<Runnable> runnableNotifications =
@@ -86,9 +86,12 @@ public class Pipelinr implements Pipeline {
                 })
             .collect(toList());
 
-    NotificationHandlingStrategy notificationHandlingStrategy =
-        notificationHandlingStrategySupplier.get();
     notificationHandlingStrategy.handle(runnableNotifications);
+  }
+
+  @Override
+  public <N extends Notification> void send(N notification) {
+    send(notification, notificationHandlingStrategySupplier.get());
   }
 
   private class HandleCommand<R, C extends Command<R>> implements Command.Middleware.Next<R> {


### PR DESCRIPTION
By default I use sorted `StopOnException` strategy, but in some cases I have to handle notifications with `ParallelWhenAll` strategy to resolve performance problem.